### PR TITLE
FEAT: 노트 페이지 노트, 폴더 데이터 패칭 로직 변경

### DIFF
--- a/src/components/notes/MarkdownEditor.tsx
+++ b/src/components/notes/MarkdownEditor.tsx
@@ -24,6 +24,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { useState, useEffect, useRef } from "react";
 import { common, createLowlight } from "lowlight";
 import { noteRepo } from "@/managers/noteRepo";
+import type { Note } from "@/types/Note";
 import { CustomReactNode } from "./CustomReactComponent";
 import { useQueryClient } from "@tanstack/react-query";
 import { IoMdRefresh } from "react-icons/io";
@@ -209,7 +210,17 @@ export default ({
         }
 
         if (noteId) {
-          const note = await noteRepo.getNoteById(noteId);
+          // 사이드바 캐시에서 먼저 탐색 (content 포함) — 중복 API 호출 방지
+          const sidebarQueries = queryClient
+            .getQueryCache()
+            .findAll({ queryKey: ["sidebar-notes"] });
+          let cachedNote: Note | undefined;
+          for (const q of sidebarQueries) {
+            const data = q.state.data as Note[] | undefined;
+            cachedNote = data?.find((n) => n.id === noteId);
+            if (cachedNote) break;
+          }
+          const note = cachedNote ?? (await noteRepo.getNoteById(noteId));
 
           if (note) {
             const normalizedContent = normalizeTableMarkdown(

--- a/src/components/sidebar/SideExpandBarNote.tsx
+++ b/src/components/sidebar/SideExpandBarNote.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 
 import { Folder } from "@/types/Folder";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueries, useQueryClient } from "@tanstack/react-query";
 import { folderRepo } from "@/managers/folderRepo";
 import { noteRepo } from "@/managers/noteRepo";
 import NewFolderField from "../NewFolderField";
@@ -18,16 +18,10 @@ import SidebarSkeletonList from "./SidebarSkeletonList";
 
 export default function SideExpandBarNote({
   path,
-  notes,
-  folders,
   selectedId,
-  isLoading,
 }: {
   path: string;
-  notes: Note[];
-  folders: Folder[];
   selectedId: string;
-  isLoading?: boolean;
 }) {
   const navigate = useNavigate();
   const { t } = useTranslation();
@@ -54,6 +48,54 @@ export default function SideExpandBarNote({
   const dragHoverFolderRef = useRef<string | "ROOT" | null>(null);
   const dropHandledRef = useRef(false);
   const queryClient = useQueryClient();
+
+  // 루트 데이터만 초기 패칭
+  const { data: rootNotes, isLoading: isLoadingNotes } = useQuery<Note[]>({
+    queryKey: ["sidebar-notes", null],
+    queryFn: () => noteRepo.getNotesByFolder(null),
+  });
+
+  const { data: rootFolders, isLoading: isLoadingFolders } = useQuery<Folder[]>({
+    queryKey: ["sidebar-folders", null],
+    queryFn: () => folderRepo.getFoldersByParentId(null),
+  });
+
+  const isLoading = isLoadingNotes || isLoadingFolders;
+
+  // 펼쳐진 폴더의 자식 데이터 lazy 패칭
+  const expandedFolderIdsArray = useMemo(
+    () => Array.from(expandedFolders),
+    [expandedFolders],
+  );
+
+  const subNoteQueries = useQueries({
+    queries: expandedFolderIdsArray.map((folderId) => ({
+      queryKey: ["sidebar-notes", folderId],
+      queryFn: () => noteRepo.getNotesByFolder(folderId),
+      staleTime: 30_000,
+    })),
+  });
+
+  const subFolderQueries = useQueries({
+    queries: expandedFolderIdsArray.map((folderId) => ({
+      queryKey: ["sidebar-folders", folderId],
+      queryFn: () => folderRepo.getFoldersByParentId(folderId),
+      staleTime: 30_000,
+    })),
+  });
+
+  // 루트 + 로드된 하위 폴더 데이터 집계
+  const notes = useMemo(() => {
+    const result: Note[] = [...(rootNotes ?? [])];
+    subNoteQueries.forEach((q) => { if (q.data) result.push(...q.data); });
+    return result;
+  }, [rootNotes, subNoteQueries]);
+
+  const folders = useMemo(() => {
+    const result: Folder[] = [...(rootFolders ?? [])];
+    subFolderQueries.forEach((q) => { if (q.data) result.push(...q.data); });
+    return result;
+  }, [rootFolders, subFolderQueries]);
 
   const resolveNoteIdFromEventTarget = (target: EventTarget | null) => {
     const targetElement =
@@ -169,8 +211,7 @@ export default function SideExpandBarNote({
       const parentId =
         creatingFolderParentId === "ROOT" ? null : creatingFolderParentId;
       await folderRepo.create(newFolderName.trim(), parentId);
-      queryClient.invalidateQueries({ queryKey: ["folders"] });
-      queryClient.invalidateQueries({ queryKey: ["notes"] });
+      queryClient.invalidateQueries({ queryKey: ["sidebar-folders"] });
       setCreatingFolderParentId(null);
       setNewFolderName("");
     } finally {
@@ -195,8 +236,8 @@ export default function SideExpandBarNote({
       return;
 
     await folderRepo.deleteFolderById(folderId);
-    queryClient.invalidateQueries({ queryKey: ["folders"] });
-    queryClient.invalidateQueries({ queryKey: ["notes"] });
+    queryClient.invalidateQueries({ queryKey: ["sidebar-folders"] });
+    queryClient.invalidateQueries({ queryKey: ["sidebar-notes"] });
   };
 
   // 폴더 이름 수정 시작
@@ -212,7 +253,7 @@ export default function SideExpandBarNote({
       await folderRepo.updateFolderById(folderId, {
         name: editingFolderName.trim(),
       });
-      queryClient.invalidateQueries({ queryKey: ["folders"] });
+      queryClient.invalidateQueries({ queryKey: ["sidebar-folders"] });
     }
     setEditingFolderId(null);
     setEditingFolderName("");
@@ -241,19 +282,15 @@ export default function SideExpandBarNote({
         try {
           dropHandledRef.current = true;
           await noteRepo.moveNoteToFolder(noteId, targetFolderId);
-          queryClient.setQueryData<Note[]>(["notes"], (old) =>
-            old
-              ? old.map((n) =>
-                  n.id === noteId ? { ...n, folderId: targetFolderId } : n,
-                )
-              : old,
+          queryClient.setQueriesData<Note[]>({ queryKey: ["sidebar-notes"] }, (old) =>
+            old ? old.map((n) => (n.id === noteId ? { ...n, folderId: targetFolderId } : n)) : old,
           );
           if (targetFolderId) {
             setExpandedFolders((prev) => new Set(prev).add(targetFolderId));
           }
         } catch (err) {
           console.error("[dragend-fallback] move failed:", err);
-          queryClient.invalidateQueries({ queryKey: ["notes"] });
+          queryClient.invalidateQueries({ queryKey: ["sidebar-notes"] });
         }
       })();
     }
@@ -314,7 +351,7 @@ export default function SideExpandBarNote({
 
       try {
         await folderRepo.updateFolderById(draggingFolder, { parentId: targetFolderId });
-        queryClient.invalidateQueries({ queryKey: ["folders"] });
+        queryClient.invalidateQueries({ queryKey: ["sidebar-folders"] });
         if (targetFolderId) {
           setExpandedFolders((prev) => new Set(prev).add(targetFolderId));
         }
@@ -345,7 +382,7 @@ export default function SideExpandBarNote({
 
     try {
       await noteRepo.moveNoteToFolder(noteId, targetFolderId);
-      queryClient.setQueryData<Note[]>(["notes"], (old) =>
+      queryClient.setQueriesData<Note[]>({ queryKey: ["sidebar-notes"] }, (old) =>
         old ? old.map((n) => (n.id === noteId ? { ...n, folderId: targetFolderId } : n)) : old,
       );
       if (targetFolderId) {
@@ -353,7 +390,7 @@ export default function SideExpandBarNote({
       }
     } catch (err) {
       console.error("[drop] note move failed:", err);
-      queryClient.invalidateQueries({ queryKey: ["notes"] });
+      queryClient.invalidateQueries({ queryKey: ["sidebar-notes"] });
     }
   };
 
@@ -396,7 +433,9 @@ export default function SideExpandBarNote({
 
   const handleDeleteNote = async (noteId: string) => {
     await noteRepo.deleteNoteById(noteId);
-    queryClient.invalidateQueries({ queryKey: ["notes"] });
+    queryClient.setQueriesData<Note[]>({ queryKey: ["sidebar-notes"] }, (old) =>
+      old?.filter((n) => n.id !== noteId),
+    );
   };
 
   return (

--- a/src/components/sidebar/SideTabBar.tsx
+++ b/src/components/sidebar/SideTabBar.tsx
@@ -1,11 +1,7 @@
 import { useLocation } from "react-router-dom";
 import { useMemo } from "react";
-import { Note } from "@/types/Note";
 import { ChatThread } from "@/types/Chat";
-import { Folder } from "@/types/Folder";
 import { threadRepo } from "@/managers/threadRepo";
-import { noteRepo } from "@/managers/noteRepo";
-import { folderRepo } from "@/managers/folderRepo";
 import { useQuery } from "@tanstack/react-query";
 import SideNavigationBar from "./SideNavigationBar";
 import ToggleSidebarExpand from "./ToggleSidebarExpand";
@@ -52,18 +48,6 @@ export default function SideTabBar({
     enabled: path.includes("/chat"),
   });
 
-  const { data: notes, isLoading: isLoadingNotes } = useQuery<Note[]>({
-    queryKey: ["notes"],
-    queryFn: () => noteRepo.getAllNotes(),
-    enabled: path.includes("/note"),
-  });
-
-  const { data: folders, isLoading: isLoadingFolders } = useQuery<Folder[]>({
-    queryKey: ["folders"],
-    queryFn: () => folderRepo.getFolderList(),
-    enabled: path.includes("/note"),
-  });
-
   return (
     <div className="flex h-full select-none">
       <SideNavigationBar
@@ -85,10 +69,7 @@ export default function SideTabBar({
               {path.includes("/note") && (
                 <SideExpandBarNote
                   path={path}
-                  notes={notes ?? []}
-                  folders={folders ?? []}
                   selectedId={selectedId ?? ""}
-                  isLoading={isLoadingNotes || isLoadingFolders}
                 />
               )}
               {path.includes("/chat") && (

--- a/src/legacy/indexeddb/dexieNoteStorage.ts
+++ b/src/legacy/indexeddb/dexieNoteStorage.ts
@@ -18,6 +18,10 @@ export const dexieNoteStorage: NoteStorageAdapter = {
     return db.notes.toArray();
   },
 
+  async listNotesByFolder(folderId: string | null): Promise<Note[]> {
+    return db.notes.filter((n) => n.folderId === folderId).toArray();
+  },
+
   async getNote(id: string): Promise<Note | null> {
     return (await db.notes.get(id)) ?? null;
   },

--- a/src/managers/noteRepo.ts
+++ b/src/managers/noteRepo.ts
@@ -43,6 +43,10 @@ export const noteRepo = {
     return (await getPreferredNoteReadStorage()).listNotes();
   },
 
+  async getNotesByFolder(folderId: string | null): Promise<Note[]> {
+    return (await getPreferredNoteReadStorage()).listNotesByFolder(folderId);
+  },
+
   async getNoteById(id: string): Promise<Note | null> {
     return (await getPreferredNoteReadStorage()).getNote(id);
   },

--- a/src/managers/storage/adapters/api/apiNoteStorage.ts
+++ b/src/managers/storage/adapters/api/apiNoteStorage.ts
@@ -7,15 +7,14 @@ import type {
   MoveNoteRecordInput,
 } from "../../contracts/noteStorage";
 
-type FolderDto = {
+function toNote(dto: {
   id: string;
-  name: string;
-  parentId: string | null;
+  title: string;
+  content: string;
+  folderId: string | null;
   createdAt: string;
   updatedAt: string;
-};
-
-function toNote(dto: { id: string; title: string; content: string; folderId: string | null; createdAt: string; updatedAt: string }): Note {
+}): Note {
   return {
     ...dto,
     createdAt: new Date(dto.createdAt).getTime(),
@@ -23,72 +22,50 @@ function toNote(dto: { id: string; title: string; content: string; folderId: str
   };
 }
 
-async function listAllFolders(): Promise<FolderDto[]> {
-  const allFolders = new Map<string, FolderDto>();
-  const pendingParents: Array<string | null> = [null];
+async function fetchAllNotes(): Promise<Note[]> {
+  const folderResult = await api.note.listFolders(undefined);
+  const allFolderIds: Array<string | null> = [null];
 
-  while (pendingParents.length > 0) {
-    const parentId = pendingParents.shift() ?? null;
-    const result = await api.note.listFolders(parentId ?? undefined);
-    if (!result.isSuccess) {
-      continue;
-    }
-
-    for (const folder of result.data) {
-      if (allFolders.has(folder.id)) {
-        continue;
+  if (folderResult.isSuccess) {
+    const pendingParents: Array<string | null> = [null];
+    const seen = new Set<string>();
+    while (pendingParents.length > 0) {
+      const parentId = pendingParents.shift()!;
+      const result = await api.note.listFolders(parentId ?? undefined);
+      if (!result.isSuccess) continue;
+      for (const folder of result.data) {
+        if (seen.has(folder.id)) continue;
+        seen.add(folder.id);
+        allFolderIds.push(folder.id);
+        pendingParents.push(folder.id);
       }
-      allFolders.set(folder.id, folder);
-      pendingParents.push(folder.id);
     }
   }
 
-  return Array.from(allFolders.values());
-}
-
-async function listAllNotesAcrossFolders(): Promise<Array<{
-  id: string;
-  title: string;
-  content: string;
-  folderId: string | null;
-  createdAt: string;
-  updatedAt: string;
-}>> {
-  const rootResult = await api.note.listNotes();
-  if (!rootResult.isSuccess) {
-    return [];
-  }
-
-  const allNotes = new Map(rootResult.data.map((note) => [note.id, note]));
-  const folders = await listAllFolders();
-
-  if (folders.length === 0) {
-    return Array.from(allNotes.values());
-  }
-
-  const folderResults = await Promise.all(
-    folders.map((folder) => api.note.listNotes(folder.id)),
+  const noteResults = await Promise.all(
+    allFolderIds.map((folderId) => api.note.listNotes(folderId ?? undefined)),
   );
 
-  for (const result of folderResults) {
-    if (!result.isSuccess) {
-      continue;
-    }
-    for (const note of result.data) {
-      allNotes.set(note.id, note);
+  const allNotes = new Map<string, Note>();
+  for (const result of noteResults) {
+    if (!result.isSuccess) continue;
+    for (const dto of result.data) {
+      allNotes.set(dto.id, toNote(dto));
     }
   }
 
-  return Array.from(allNotes.values()).sort(
-    (a, b) =>
-      new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
-  );
+  return Array.from(allNotes.values()).sort((a, b) => b.updatedAt - a.updatedAt);
 }
 
 export const apiNoteStorage: NoteStorageAdapter = {
   async listNotes(): Promise<Note[]> {
-    const allNotes = await listAllNotesAcrossFolders();
-    return allNotes.map(toNote);
+    return fetchAllNotes();
+  },
+
+  async listNotesByFolder(folderId: string | null): Promise<Note[]> {
+    const result = await api.note.listNotes(folderId ?? undefined);
+    if (!result.isSuccess) return [];
+    return result.data.map(toNote);
   },
 
   async getNote(id: string): Promise<Note | null> {
@@ -98,10 +75,10 @@ export const apiNoteStorage: NoteStorageAdapter = {
   },
 
   async searchNotes(query: string): Promise<Note[]> {
-    const allNotes = await listAllNotesAcrossFolders();
-    return allNotes
-      .filter((dto) => dto.title.includes(query) || dto.content.includes(query))
-      .map(toNote);
+    const allNotes = await fetchAllNotes();
+    return allNotes.filter(
+      (note) => note.title.includes(query) || note.content.includes(query),
+    );
   },
 
   async createNoteRecord(input: CreateNoteRecordInput): Promise<Note> {
@@ -115,7 +92,10 @@ export const apiNoteStorage: NoteStorageAdapter = {
     return toNote(result.data);
   },
 
-  async updateNoteRecord(id: string, input: UpdateNoteRecordInput): Promise<void> {
+  async updateNoteRecord(
+    id: string,
+    input: UpdateNoteRecordInput,
+  ): Promise<void> {
     await api.note.updateNote(id, {
       title: input.title,
       content: input.content,

--- a/src/managers/storage/adapters/sqlite/sqliteRendererNoteStorage.ts
+++ b/src/managers/storage/adapters/sqlite/sqliteRendererNoteStorage.ts
@@ -17,6 +17,11 @@ export const sqliteRendererNoteStorage: NoteStorageAdapter = {
     return window.graphnodeAPI.listSQLiteNotes();
   },
 
+  async listNotesByFolder(folderId: string | null): Promise<Note[]> {
+    const all = await window.graphnodeAPI.listSQLiteNotes();
+    return all.filter((n) => n.folderId === folderId);
+  },
+
   async getNote(id: string): Promise<Note | null> {
     return window.graphnodeAPI.getSQLiteNoteById(id);
   },

--- a/src/managers/storage/contracts/noteStorage.ts
+++ b/src/managers/storage/contracts/noteStorage.ts
@@ -23,6 +23,7 @@ export type MoveNoteRecordInput = {
 export interface NoteStorageAdapter {
   createNoteRecord(input: CreateNoteRecordInput): Promise<Note>;
   listNotes(): Promise<Note[]>;
+  listNotesByFolder(folderId: string | null): Promise<Note[]>;
   getNote(id: string): Promise<Note | null>;
   searchNotes(query: string): Promise<Note[]>;
   updateNoteRecord(id: string, input: UpdateNoteRecordInput): Promise<void>;


### PR DESCRIPTION
- 첫 로딩에서 루트에 있는 아이템만 보이기
- 폴더 토글 될 때 해당 폴더의 하위 아이템 패치
- 사이드바에서 패치한 데이터에 있는 노트 컨텐츠 캐시 사용해서 노트 컨텐츠 표시하기